### PR TITLE
Fix (ci): Fix Dockerfile ENTRYPOINT to use array syntax to prevent entrypoint from being transformed into shell form CMD

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -35,5 +35,5 @@ RUN apk --no-cache add ca-certificates
 ARG OUTBIN
 COPY --from=builder $OUTBIN /$BIN
 ENV BIN=$BIN
-ENTRYPOINT /$BIN
+ENTRYPOINT [ "/openvpn_exporter" ]
 EXPOSE 9176


### PR DESCRIPTION
If `ENTRYPOINT` is: `["/bin/sh", "-c", "/openvpn_exporter"]`, then `CMD` which may contain flags will be ignored.